### PR TITLE
Require plugin name

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -71,8 +71,6 @@ var pluginsInstallCmd = &Command{
 			return
 		}
 		Errf("Installing plugin %s... ", name)
-		fmt.Println(len(name))
-
 		must(node.InstallPackage(name))
 		plugin := getPlugin(name)
 		if plugin == nil || len(plugin.Commands) == 0 {

--- a/plugins.go
+++ b/plugins.go
@@ -66,7 +66,13 @@ var pluginsInstallCmd = &Command{
 
 	Run: func(ctx *Context) {
 		name := ctx.Args["name"]
+		if len(name) == 0 {
+			Errln("Must specify a plugin name")
+			return
+		}
 		Errf("Installing plugin %s... ", name)
+		fmt.Println(len(name))
+
 		must(node.InstallPackage(name))
 		plugin := getPlugin(name)
 		if plugin == nil || len(plugin.Commands) == 0 {


### PR DESCRIPTION
Plugin name was not required when using topic commands, causing panic if missing, as the empty string was not caught.

i.e. `heroku plugins:install`

Initially looked at putting code in cli.go, however the line in parseArgs with the loop followed by switch case for checking args has no sensible way to check for the (usually optional) absence of args:

`for i := 0; i < len(args); i++ {`

Another solution might be to add an additional check in cli.go, for the length of additional args (for topics that require it). Empty strings will likely cause further bugs.
