### PR TITLE
prevent update from forking needlessly

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,13 +44,11 @@ func init() {
 
 func main() {
 	defer handlePanic()
-	if IsUpdateNeeded("hard") {
-		Update(Channel, true)
-	}
-	if IsUpdateNeeded("soft") {
+	Update(Channel, "block")
+	SetupNode()
+	if IsUpdateNeeded("background") {
 		TriggerBackgroundUpdate()
 	}
-	SetupNode()
 	err := cli.Run(os.Args)
 	if err == ErrHelp {
 		// Command wasn't found so load the plugins and try again


### PR DESCRIPTION
solve a bug where updates would fork while iojs was setting up
check if updates are needed just before performing updates