### PR TITLE
Add wantsApp flag for filling apps but not enforce presence.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -41,11 +41,11 @@ func (cli *Cli) Run(args []string) (err error) {
 	if err != nil {
 		return err
 	}
-	if ctx.Command.NeedsApp {
+	if ctx.Command.NeedsApp || ctx.Command.WantsApp {
 		if ctx.App == "" {
 			ctx.App = app()
 		}
-		if ctx.App == "" {
+		if ctx.App == "" && ctx.Command.NeedsApp {
 			return ErrAppNeeded
 		}
 	}
@@ -90,7 +90,7 @@ func parseVarArgs(command *Command, args []string) (result []string, flags map[s
 		f := flag
 		possibleFlags = append(possibleFlags, &f)
 	}
-	if command.NeedsApp {
+	if command.NeedsApp || command.WantsApp {
 		possibleFlags = append(possibleFlags, appFlag, remoteFlag)
 	}
 	for i := 0; i < len(args); i++ {

--- a/command.go
+++ b/command.go
@@ -21,6 +21,7 @@ type Command struct {
 	FullHelp     string             `json:"fullHelp"`
 	Hidden       bool               `json:"hidden"`
 	NeedsApp     bool               `json:"needsApp"`
+	WantsApp     bool               `json:"wantsApp"`
 	NeedsAuth    bool               `json:"needsAuth"`
 	VariableArgs bool               `json:"variableArgs"`
 	Args         []Arg              `json:"args"`


### PR DESCRIPTION
I want to be able to have `ctx.app` in the plugins but not enforcing its presence.
I have actions that may or may not require an app.
Is there a different way to do that?