### PR TITLE
Include correct default addons plugin

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ var cli = &Cli{}
 
 // BuiltinPlugins are the core plugins that will be autoinstalled
 var BuiltinPlugins = []string{
-	"heroku-addons",
+	"heroku-cli-addons",
 	"heroku-apps",
 	"heroku-fork",
 	"heroku-git",


### PR DESCRIPTION
The new plugin is named `heroku-cli-addons`. This is causing folks to be missing the `heroku addons` command when the CLI updates.

@dickeyxxx 
cc @heroku/add-ons 