### PR TITLE
ignore '.staging' plugin

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -391,7 +391,7 @@ func PluginNamesNotSymlinked() []string {
 }
 
 func ignorePlugin(plugin string) bool {
-	ignored := []string{".bin", ".DS_Store", "node-inspector"}
+	ignored := []string{".bin", ".DS_Store", "node-inspector", ".staging"}
 	for _, p := range ignored {
 		if plugin == p {
 			return true


### PR DESCRIPTION
some users have a .staging directory in the node_modules directory
I'm not sure where it comes from, but it can safely be ignored.