### PR TITLE
add package.json to ~/.heroku

### DIFF
--- a/gode/packages.go
+++ b/gode/packages.go
@@ -38,7 +38,7 @@ func InstallPackage(packages ...string) error {
 	args := append([]string{"install"}, packages...)
 	_, stderr, err := execNpm(args...)
 	if err != nil {
-		return errors.New("Error installing package. \n" + stderr + "\nTry running again with GODE_DEBUG=info to see more output.")
+		return errors.New("Error installing package.\n" + stderr + "\nTry running again with GODE_DEBUG=info to see more output.")
 	}
 	return nil
 }
@@ -103,6 +103,7 @@ func execNpm(args ...string) (string, string, error) {
 func environ() []string {
 	env := append(os.Environ(), "NPM_CONFIG_SPIN=false")
 	env = append(env, "NPM_CONFIG_AUTO_AUTH=false")
+	env = append(env, "NPM_CONFIG_SAVE=true", "NPM_CONFIG_SAVE_EXACT=false", "NPM_CONFIG_SAVE_PREFIX=>=")
 	env = append(env, "NPM_CONFIG_CACHE="+filepath.Join(rootPath, ".npm-cache"))
 	env = append(env, "NPM_CONFIG_REGISTRY="+registry)
 	return env

--- a/gode/setup.go
+++ b/gode/setup.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -50,6 +51,7 @@ You'll need to compile the tarball from nodejs.org and place it in ~/.heroku/nod
 		return err
 	}
 	SetRootPath(rootPath) // essentially sets this node as the current one
+	addPackageJSON()
 	return t.clearOldNodeInstalls()
 }
 
@@ -179,4 +181,19 @@ func tmpDir(prefix string) string {
 		panic(err)
 	}
 	return dir
+}
+
+func addPackageJSON() {
+	path := filepath.Join(rootPath, "package.json")
+	if exists, _ := fileExists(path); exists {
+		return
+	}
+	d := []byte(`{
+		"description": "Heroku CLI Plugins",
+		"repository": "heroku/heroku-cli",
+		"license": "ISC"
+	}`)
+	if err := ioutil.WriteFile(path, d, 0644); err != nil {
+		log.Println(err)
+	}
 }


### PR DESCRIPTION
This removes some warnings when GODE_DEBUG is set and allows users to
run the CLI on locked down versions of the plugins by directly modifying
the package.json file.