### PR TITLE
install built-in plugins only after running any built in commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,8 +76,8 @@ func main() {
 	runtime.GOMAXPROCS(1) // more procs causes runtime: failed to create new OS thread on Ubuntu
 	Update(Channel, "block")
 	SetupNode()
-	SetupBuiltinPlugins()
 	err := cli.Run(os.Args)
+	SetupBuiltinPlugins()
 	TriggerBackgroundUpdate()
 	if err == ErrHelp {
 		// Command wasn't found so load the plugins and try again


### PR DESCRIPTION
This allows us to run something like `heroku version` or `heroku update`
wihout installing the built-in plugins. (In case that step is broken for
whatever reason).