### PR TITLE
fix npm always-auth disable

### DIFF
--- a/gode/packages.go
+++ b/gode/packages.go
@@ -110,7 +110,7 @@ func execNpm(args ...string) (string, string, error) {
 }
 
 func environ() []string {
-	env := append(os.Environ(), "NPM_CONFIG_AUTO_AUTH=false")
+	env := append(os.Environ(), "NPM_CONFIG_ALWAYS_AUTH=false")
 	env = append(env, "NPM_CONFIG_CACHE="+filepath.Join(rootPath, ".npm-cache"))
 	env = append(env, "NPM_CONFIG_REGISTRY="+registry)
 	return env


### PR DESCRIPTION
I have no idea why this was set to AUTO_AUTH. That doesn't seem like it
was ever a config for npm.

Fixes https://github.com/heroku/heroku/issues/1832