### PR TITLE
do not error if plugin does not exist

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -387,7 +387,7 @@ func isPluginSymlinked(plugin string) bool {
 	path := filepath.Join(AppDir(), "node_modules", plugin)
 	fi, err := os.Lstat(path)
 	if err != nil {
-		panic(err)
+		return false
 	}
 	return fi.Mode()&os.ModeSymlink != 0
 }


### PR DESCRIPTION
it's possible now to not have the directory and have it in the plugin
cache, this causes a panic. We should just return false here.