### PR TITLE
force updating of outdated plugins

### DIFF
--- a/gode/packages.go
+++ b/gode/packages.go
@@ -52,22 +52,20 @@ func RemovePackage(name string) error {
 	return nil
 }
 
-// UpdatePackages updates all packages.
-func UpdatePackages() (string, error) {
-	stdout, stderr, err := execNpm("update")
+// OutdatedPackages returns a map of packages and their latest version
+func OutdatedPackages(names ...string) (map[string]string, error) {
+	args := append([]string{"outdated", "--json"}, names...)
+	stdout, stderr, err := execNpm(args...)
 	if err != nil {
-		return stdout, errors.New(stderr)
+		return nil, errors.New(stderr)
 	}
-	return stdout, nil
-}
-
-// UpdatePackage updates a package.
-func UpdatePackage(name string) (string, error) {
-	stdout, stderr, err := execNpm("update", name)
-	if err != nil {
-		return stdout, errors.New(stderr)
+	var outdated map[string]struct{ Latest string }
+	json.Unmarshal([]byte(stdout), &outdated)
+	packages := make(map[string]string, len(outdated))
+	for name, versions := range outdated {
+		packages[name] = versions.Latest
 	}
-	return stdout, nil
+	return packages, nil
 }
 
 func npmCmd(args ...string) (*exec.Cmd, error) {

--- a/gode/packages_test.go
+++ b/gode/packages_test.go
@@ -37,11 +37,14 @@ func TestRemovePackage(t *testing.T) {
 	}
 }
 
-func TestUpdatePackages(t *testing.T) {
+func TestOutdatedPackages(t *testing.T) {
 	setup()
-	must(InstallPackage("request"))
-	_, err := UpdatePackages()
+	must(InstallPackage("heroku-cli-util@1.0.0"))
+	packages, err := OutdatedPackages("heroku-cli-util")
 	must(err)
+	if packages["heroku-cli-util"] == "" {
+		t.Fatal("heroku-cli-util not found")
+	}
 }
 
 func TestPackagesGithubPackage(t *testing.T) {

--- a/io.go
+++ b/io.go
@@ -213,3 +213,10 @@ func supportsColor() bool {
 	}
 	return os.Getenv("COLOR") != "false"
 }
+
+func plural(word string, count int) string {
+	if count == 1 {
+		return word
+	}
+	return word + "s"
+}

--- a/plugin_cache.go
+++ b/plugin_cache.go
@@ -8,15 +8,6 @@ import (
 
 var pluginCachePath = filepath.Join(AppDir(), "plugin-cache.json")
 
-// UpdatePluginCache updates all the plugins in ~/.heroku/plugin-cache.json
-func UpdatePluginCache() {
-	cache := FetchPluginCache()
-	for name := range cache {
-		cache[name] = getPlugin(name, true)
-	}
-	savePluginCache(cache)
-}
-
 // AddPluginsToCache adds/updates a set of plugins to ~/.heroku/plugin-cache.json
 func AddPluginsToCache(plugins ...*Plugin) {
 	cache := FetchPluginCache()


### PR DESCRIPTION
`npm update` doesn't seem to update for some users. They get this error
for some reason:

```
npm verb outdated not updating heroku-apps because it's currently at the
maximum version that matches its specified semver range
```

The best way I found to fix this was to more directly find outdated
packages and update them by installing the specific, newest version.