### PR TITLE
increase blocking updates to 90 day intervals

### DIFF
--- a/update.go
+++ b/update.go
@@ -146,7 +146,7 @@ func IsUpdateNeeded(t string) bool {
 	if t == "background" {
 		return time.Since(f.ModTime()) > 4*time.Hour
 	} else if t == "block" {
-		return time.Since(f.ModTime()) > 336*time.Hour
+		return time.Since(f.ModTime()) > 2160*time.Hour // 90 days
 	}
 	return true
 }


### PR DESCRIPTION
These can have a longer interval, no reason to block the user if they only use the toolbelt every couple of weeks.