### PR TITLE
reexec cli after updating

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -290,6 +290,8 @@ func swallowSignal(s os.Signal) {
 
 func getExitCode(err error) int {
 	switch e := err.(type) {
+	case nil:
+		return 0
 	case *exec.ExitError:
 		status, ok := e.Sys().(syscall.WaitStatus)
 		if !ok {


### PR DESCRIPTION
This change will force an update of the CLI with the updated Go code
after it is updated by re-executing the command with the same arguments.