### PR TITLE
ignore plugins if they do not exist

### DIFF
--- a/plugin_cache.go
+++ b/plugin_cache.go
@@ -19,6 +19,13 @@ func AddPluginsToCache(plugins ...*Plugin) {
 	savePluginCache(cache)
 }
 
+// RemovePluginFromCache will take a plugin and remove it from the list
+func RemovePluginFromCache(name string) {
+	cache := FetchPluginCache()
+	delete(cache, name)
+	savePluginCache(cache)
+}
+
 func savePluginCache(cache map[string]*Plugin) {
 	f, err := os.Create(pluginCachePath)
 	if err != nil {

--- a/plugins.go
+++ b/plugins.go
@@ -185,14 +185,19 @@ Example:
   $ heroku plugins`,
 
 	Run: func(ctx *Context) {
+		var plugins []string
 		for _, plugin := range GetPlugins() {
 			if plugin != nil && len(plugin.Commands) > 0 {
 				symlinked := ""
 				if isPluginSymlinked(plugin.Name) {
 					symlinked = " (symlinked)"
 				}
-				Println(plugin.Name, plugin.Version, symlinked)
+				plugins = append(plugins, fmt.Sprintf("%s %s %s", plugin.Name, plugin.Version, symlinked))
 			}
+		}
+		sort.Strings(plugins)
+		for _, plugin := range plugins {
+			Println(plugin)
 		}
 	},
 }

--- a/plugins.go
+++ b/plugins.go
@@ -185,6 +185,7 @@ Example:
   $ heroku plugins`,
 
 	Run: func(ctx *Context) {
+		SetupBuiltinPlugins()
 		var plugins []string
 		for _, plugin := range GetPlugins() {
 			if plugin != nil && len(plugin.Commands) > 0 {

--- a/plugins.go
+++ b/plugins.go
@@ -172,6 +172,7 @@ var pluginsUninstallCmd = &Command{
 		Errf("Uninstalling plugin %s... ", name)
 		err := gode.RemovePackage(name)
 		ExitIfError(err)
+		RemovePluginFromCache(name)
 		Errln("done")
 	},
 }


### PR DESCRIPTION
this fixes the bug that makes `plugins:uninstall` not work as well as making the CLI more consistent with the plugins actually installed and not just in the cache

* sorted output of `heroku plugins` (v4 only)
* ignore plugins that do not actually have a directory in `~/.heroku/node_modules`
* remove plugins from cache after uninstalling