### PR TITLE
List apps instead of Git remote when typing addons with many ones

### DIFF
--- a/git.go
+++ b/git.go
@@ -138,8 +138,8 @@ func remoteFromGitConfig() string {
 	return strings.TrimSpace(string(b))
 }
 
-func errMultipleHerokuRemotes(remotes []string) error {
-	return errors.New("multiple apps in git remotes\nremotes: " + strings.Join(remotes, " "))
+func errMultipleHerokuRemotes(apps []string) error {
+	return errors.New("multiple apps in git remotes\napps: " + strings.Join(apps, " "))
 }
 
 func appFromGitRemote(remote string) (string, error) {
@@ -177,7 +177,7 @@ func appFromGitRemote(remote string) (string, error) {
 	}
 	remoteValues := uniqueMapValues(remotes)
 	if len(remoteValues) > 1 {
-		return "", errMultipleHerokuRemotes(mapKeys(remotes))
+		return "", errMultipleHerokuRemotes(remoteValues)
 	}
 	for _, v := range remotes {
 		return v, nil

--- a/git.go
+++ b/git.go
@@ -138,7 +138,7 @@ func remoteFromGitConfig() string {
 	return strings.TrimSpace(string(b))
 }
 
-func errMultipleHerokuRemotes(apps []string) error {
+func errMultipleHerokuApps(apps []string) error {
 	return errors.New("multiple apps in git remotes\napps: " + strings.Join(apps, " "))
 }
 
@@ -177,7 +177,7 @@ func appFromGitRemote(remote string) (string, error) {
 	}
 	remoteValues := uniqueMapValues(remotes)
 	if len(remoteValues) > 1 {
-		return "", errMultipleHerokuRemotes(remoteValues)
+		return "", errMultipleHerokuApps(remoteValues)
 	}
 	for _, v := range remotes {
 		return v, nil


### PR DESCRIPTION
When typing `heroku addons` command with multiple apps in a project it displays Git remotes:
```
 ▸    multiple apps in git remotes
 ▸    remotes: git_remote_a git_remote_b
```

But it should be more useful to directly displays App names since we will have to pass on them as an argument:
```
 ▸    multiple apps in git remotes
 ▸    apps: app_a app_b
```