### PR TITLE
Add heroku-pipelines as a default package

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ var BuiltinPlugins = []string{
 	"heroku-fork",
 	"heroku-git",
 	"heroku-local",
+	"heroku-pipelines",
 	"heroku-run",
 	"heroku-spaces",
 	"heroku-status",


### PR DESCRIPTION
We are going live today! Pipelines are officially GA, so it seems reasonable that heroku-pipelines becomes a default plugin. We recently updated it to v1.0 to reflect it's stability.