### PR TITLE
fix double updating bug

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,7 +85,11 @@ func main() {
 	defer handlePanic()
 	runtime.GOMAXPROCS(1) // more procs causes runtime: failed to create new OS thread on Ubuntu
 	ShowDebugInfo()
-	Update(Channel, "block")
+	if !(len(os.Args) >= 2 && os.Args[1] == "update") {
+		// skip blocking update if the command is to update
+		// otherwise it will update twice
+		Update(Channel, "block")
+	}
 	SetupNode()
 	err := cli.Run(os.Args)
 	SetupBuiltinPlugins()

--- a/update.go
+++ b/update.go
@@ -79,7 +79,7 @@ func updatePlugins() {
 	if len(plugins) == 0 {
 		return
 	}
-	Err("Updating plugins... ")
+	Err("heroku-cli: Updating plugins... ")
 	packages, err := gode.OutdatedPackages(plugins...)
 	PrintError(err, true)
 	if len(packages) > 0 {
@@ -116,7 +116,11 @@ func updateCLI(channel string) {
 		golock.Unlock(updateLockPath)
 	}
 	defer unlock()
-	Errf("Updating Heroku v4 CLI to %s (%s)... ", manifest.Version, manifest.Channel)
+	if manifest.Channel == "master" {
+		Errf("heroku-cli: Updating to %s... ", manifest.Version)
+	} else {
+		Errf("heroku-cli: Updating to %s (%s)... ", manifest.Version, manifest.Channel)
+	}
 	build := manifest.Builds[runtime.GOOS][runtime.GOARCH]
 	// on windows we can't remove an existing file or remove the running binary
 	// so we download the file to binName.new


### PR DESCRIPTION
running `heroku update` still causes the blocking update to run. This is happening because when the CLI is updated, the update lock file is cleared to force an autoupdate and reexec of the command. Generally this is good, because it will make sure that everything is updated using the new CLI. The problem is when the command is actually update, it will force a blocking update, then run the command which is to update.

This just checks before running a blocking update if the command is to update. If so, there is no need to do the blocking update step.

before:
```
$ heroku update master
Updating Heroku v4 CLI to 4.27.25-3b727e5 (master)... done
heroku-cli: Adding dependencies... done
Updating plugins... no plugins to update.
Updating plugins... no plugins to update.
```

after:
```
$ heroku update dev
Updating Heroku v4 CLI to 4.27.25-b97ac29 (dev)... done
heroku-cli: Adding dependencies... done
heroku-cli: Updating plugins... no plugins to update.
```