### PR TITLE
fix bugs with plugin parsing

### DIFF
--- a/plugins.go
+++ b/plugins.go
@@ -291,12 +291,16 @@ func ParsePlugin(name string) (*Plugin, error) {
 
 	console.log(JSON.stringify(plugin))`
 	cmd := gode.RunScript(script)
-	output, err := cmd.CombinedOutput()
+	cmd.Stderr = Stderr
+	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("Error reading plugin: %s\n%s\n%s", name, err, string(output))
+		return nil, fmt.Errorf("Error reading plugin: %s\n%s", name, err)
 	}
 	var plugin Plugin
-	json.Unmarshal([]byte(output), &plugin)
+	err = json.Unmarshal([]byte(output), &plugin)
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing plugin: %s\n%s\n%s", name, err, string(output))
+	}
 	for _, command := range plugin.Commands {
 		command.Plugin = plugin.Name
 		command.Help = strings.TrimSpace(command.Help)


### PR DESCRIPTION
If the plugin fails to parse it formerly would just exit silently and
all plugins would fail to install.

Also, if the plugin output anything on stderr it would try to parse it
and also fail.

This redirects stderr out to the terminal and shows the parsing error if
any.