### PR TITLE
fix race condition with updater

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -5,8 +5,8 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/dickeyxxx/golock",
-			"Comment": "v1.0.0-3-g4121076",
-			"Rev": "41210765bf2c6815e195d1192af6da935cd79b95"
+			"Comment": "v1.1.0",
+			"Rev": "ae2e6b7e683fc65b06e64361d9386c7278b677a0"
 		},
 		{
 			"ImportPath": "github.com/dickeyxxx/netrc",

--- a/file.go
+++ b/file.go
@@ -1,6 +1,11 @@
 package main
 
-import "os"
+import (
+	"math/rand"
+	"os"
+	"strconv"
+	"time"
+)
 
 func fileExists(path string) (bool, error) {
 	if _, err := os.Stat(path); err != nil {
@@ -10,4 +15,9 @@ func fileExists(path string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+func randomIntString(n int) string {
+	source := rand.NewSource(time.Now().UnixNano())
+	return strconv.Itoa(rand.New(source).Intn(n))
 }

--- a/plugins.go
+++ b/plugins.go
@@ -422,7 +422,9 @@ func pluginPath(plugin string) string {
 // lock a plugin for reading
 func readLockPlugin(name string) {
 	lockfile := updateLockPath + "." + name
-	if exists, _ := fileExists(lockfile); exists {
+	locked, err := golock.IsLocked(lockfile)
+	LogIfError(err)
+	if locked {
 		lockPlugin(name)
 		unlockPlugin(name)
 	}

--- a/vendor/github.com/dickeyxxx/golock/.travis.yml
+++ b/vendor/github.com/dickeyxxx/golock/.travis.yml
@@ -1,11 +1,10 @@
 language: go
 
 go:
-  - 1.4
+  - 1.6
 
 install:
   - go get -v -u github.com/golang/lint/golint
-  - go get -v -u golang.org/x/tools/cmd/vet
   - go get -v
   - go build -v ./...
 


### PR DESCRIPTION
It seems even though we have a lockfile in place, 2 updates can still
happen at once. This fixes the file renaming to work even if 2 updates
are happening at the same time.